### PR TITLE
Refactor: Improve readability and maintainability of Crane Visualizer panel

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,6 @@
+// This file contains constants used across the application.
+
+export const DEFAULT_TOPIC = "/aggregated_svgs";
+export const DEFAULT_VIEWBOX_ASPECT_RATIO = 0.6;
+// Potentially add INITIAL_VIEWBOX_WIDTH = 10000; if needed elsewhere,
+// but it's currently well-encapsulated in usePanelConfig's defaultConfig.

--- a/src/crane_visualizer_panel.tsx
+++ b/src/crane_visualizer_panel.tsx
@@ -80,9 +80,8 @@ const CraneVisualizer: React.FC<{ context: PanelExtensionContext }> = ({ context
     // Panel is responsible for managing its subscriptions
     context.subscribe([{ topic }]);
     return () => {
-      // Unsubscribe when the topic changes or the panel is unmounted
-      // context.unsubscribe expects an array of subscriptionIds (topic strings)
-      context.unsubscribe([topic]);
+      // Unsubscribe from all topics when the topic changes or the panel is unmounted
+      context.unsubscribeAll();
     };
   }, [topic, context]); // Added context as a dependency, as context.subscribe/unsubscribe are used.
 

--- a/src/crane_visualizer_panel.tsx
+++ b/src/crane_visualizer_panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useState, useEffect, FC, memo } from "react";
+import React, { useCallback, useLayoutEffect, useState, useEffect, FC, memo } from "react";
 import {
   PanelExtensionContext,
   SettingsTree,
@@ -13,9 +13,9 @@ import ReactDOM from "react-dom";
 import { StrictMode } from "react";
 import { usePanZoom } from "./hooks/usePanZoom";
 import { usePanelConfig } from "./hooks/usePanelConfig"; // Hook import
-import { PanelConfig, NamespaceConfig } from "../settings_utils"; // Type imports
-import { createNamespaceFields, handleSettingsAction } from "../settings_utils"; // Import utils
-import { DEFAULT_TOPIC, DEFAULT_VIEWBOX_ASPECT_RATIO } from "../constants"; // Import constants
+import { PanelConfig, NamespaceConfig } from "./settings_utils"; // Type imports
+import { createNamespaceFields, handleSettingsAction } from "./settings_utils"; // Import utils
+import { DEFAULT_TOPIC, DEFAULT_VIEWBOX_ASPECT_RATIO } from "./constants"; // Import constants
 
 interface SvgPrimitiveArray {
   layer: string; // "parent/child1/child2"のような階層パス
@@ -81,7 +81,8 @@ const CraneVisualizer: React.FC<{ context: PanelExtensionContext }> = ({ context
     context.subscribe([{ topic }]);
     return () => {
       // Unsubscribe when the topic changes or the panel is unmounted
-      context.unsubscribe([{ topic }]);
+      // context.unsubscribe expects an array of subscriptionIds (topic strings)
+      context.unsubscribe([topic]);
     };
   }, [topic, context]); // Added context as a dependency, as context.subscribe/unsubscribe are used.
 

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -1,0 +1,86 @@
+import { useCallback, Dispatch, SetStateAction, MouseEvent as ReactMouseEvent, WheelEvent as ReactWheelEvent } from "react";
+
+const PAN_VIEWBOX_PIXEL_MOTION_DIVISOR = 400; // Higher values make panning slower relative to pixel motion.
+const ZOOM_IN_FACTOR = 1.2;
+const ZOOM_OUT_FACTOR = 0.8;
+const MAX_ZOOM_RATIO = 10; // Represents 10x zoom in or 10x zoom out from initial.
+
+interface UsePanZoomOptions {
+  initialViewBox: string;
+  setViewBox: Dispatch<SetStateAction<string>>;
+}
+
+interface PanZoomHandlers {
+  handleMouseDown: (event: ReactMouseEvent<SVGSVGElement>) => void;
+  handleWheel: (event: ReactWheelEvent<SVGSVGElement>) => void;
+}
+
+export const usePanZoom = ({ // No direct React.* usage in function body if types are aliased/imported directly
+  initialViewBox,
+  setViewBox,
+}: UsePanZoomOptions): PanZoomHandlers => {
+  const handleMouseDown = useCallback(
+    (e: ReactMouseEvent<SVGSVGElement>) => {
+      const startX = e.clientX;
+      const startY = e.clientY;
+      // Assuming viewBox is a string like "x y width height"
+      const [vx, vy, vwidth, vheight] = initialViewBox.split(" ").map(Number);
+
+      const handleMouseMove = (event: MouseEvent) => {
+        const dx = event.clientX - startX;
+        const dy = event.clientY - startY;
+        
+        // Use a scaling factor relative to the viewBox dimensions.
+        const scaledDx = (dx * vwidth) / PAN_VIEWBOX_PIXEL_MOTION_DIVISOR;
+        const scaledDy = (dy * vheight) / PAN_VIEWBOX_PIXEL_MOTION_DIVISOR; // Maintain aspect ratio of panning speed
+
+        setViewBox(`${vx - scaledDx} ${vy - scaledDy} ${vwidth} ${vheight}`);
+      };
+
+      const handleMouseUp = () => {
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [initialViewBox, setViewBox]
+  );
+
+  const handleWheel = useCallback(
+    (e: ReactWheelEvent<SVGSVGElement>) => {
+      e.preventDefault();
+      const [x, y, width, height] = initialViewBox.split(" ").map(Number);
+      const scale = e.deltaY > 0 ? ZOOM_IN_FACTOR : ZOOM_OUT_FACTOR;
+
+      // Define min/max zoom levels based on initial width/height and MAX_ZOOM_RATIO
+      const minWidth = width / MAX_ZOOM_RATIO;
+      const maxWidth = width * MAX_ZOOM_RATIO;
+      const minHeight = height / MAX_ZOOM_RATIO;
+      const maxHeight = height * MAX_ZOOM_RATIO;
+
+      let newWidth = width * scale;
+      let newHeight = height * scale;
+
+      // Apply zoom constraints
+      newWidth = Math.max(minWidth, Math.min(maxWidth, newWidth));
+      newHeight = Math.max(minHeight, Math.min(maxHeight, newHeight));
+      
+      // If new dimensions are clamped, adjust scale to maintain aspect ratio (optional)
+      // This part can be tricky; for now, we'll allow aspect ratio to change slightly at limits
+      // or ensure clamping logic respects aspect ratio.
+      // For simplicity, current clamping might alter aspect ratio if one dimension hits limit before other.
+
+      const centerX = x + width / 2;
+      const centerY = y + height / 2;
+      const newX = centerX - newWidth / 2;
+      const newY = centerY - newHeight / 2;
+
+      setViewBox(`${newX} ${newY} ${newWidth} ${newHeight}`);
+    },
+    [initialViewBox, setViewBox]
+  );
+
+  return { handleMouseDown, handleWheel };
+};

--- a/src/hooks/usePanelConfig.ts
+++ b/src/hooks/usePanelConfig.ts
@@ -1,0 +1,110 @@
+// This file will contain the usePanelConfig custom React hook.
+import { useState, useCallback } from "react";
+import { PanelConfig } from "../settings_utils"; // Import PanelConfig type (NamespaceConfig is used via PanelConfig)
+
+interface UsePanelConfigOptions {
+  defaultConfig: PanelConfig;
+  initialState?: Partial<PanelConfig>; // initialState from context can be partial
+}
+
+interface PanelConfigUpdaters {
+  config: PanelConfig;
+  setBackgroundColor: (color: string) => void;
+  setViewBoxWidth: (width: number) => void;
+  setNamespaceVisibility: (layerPath: string | string[], isVisible: boolean) => void;
+  initializeNamespaces: (layers: string[]) => void;
+}
+
+export const usePanelConfig = ({
+  defaultConfig,
+  initialState,
+}: UsePanelConfigOptions): PanelConfigUpdaters => {
+  const [config, setConfig] = useState<PanelConfig>(() => {
+    const mergedConfig = { ...defaultConfig };
+    if (initialState) {
+      mergedConfig.backgroundColor = initialState.backgroundColor ?? defaultConfig.backgroundColor;
+      mergedConfig.viewBoxWidth = initialState.viewBoxWidth ?? defaultConfig.viewBoxWidth;
+      // Deep merge for namespaces is more complex, handle it carefully
+      // For now, simple overwrite, but ideally, it should be a deep merge
+      mergedConfig.namespaces = initialState.namespaces ? JSON.parse(JSON.stringify(initialState.namespaces)) : defaultConfig.namespaces;
+    }
+    return mergedConfig;
+  });
+
+  const setBackgroundColor = useCallback((color: string) => {
+    setConfig((prevConfig) => ({ ...prevConfig, backgroundColor: color }));
+  }, []);
+
+  const setViewBoxWidth = useCallback((width: number) => {
+    setConfig((prevConfig) => ({ ...prevConfig, viewBoxWidth: width }));
+  }, []);
+
+  const setNamespaceVisibility = useCallback(
+    (layerPath: string | string[], isVisible: boolean) => {
+      setConfig((prevConfig) => {
+        const newConfig = JSON.parse(JSON.stringify(prevConfig)); // Deep clone
+        let current = newConfig.namespaces;
+        const pathArray = Array.isArray(layerPath) ? layerPath : layerPath.split("/"); // Assuming '/' delimiter if string
+
+        pathArray.forEach((part, index) => {
+          if (index === pathArray.length - 1) {
+            if (!current[part]) {
+              current[part] = { visible: isVisible, children: {} }; // Initialize if not exists
+            } else {
+              current[part].visible = isVisible;
+            }
+          } else {
+            if (!current[part]) {
+              current[part] = { visible: true, children: {} }; // Create path if not exists
+            }
+            if (!current[part].children) {
+                current[part].children = {}; // Ensure children object exists
+            }
+            current = current[part].children;
+          }
+        });
+        return newConfig;
+      });
+    },
+    []
+  );
+
+  const initializeNamespaces = useCallback((layers: string[]) => {
+    setConfig((prevConfig) => {
+      const newConfig = JSON.parse(JSON.stringify(prevConfig)); // Deep clone
+      let changed = false;
+      layers.forEach((layer) => {
+        // This correctly handles hierarchical layer paths like "parent/child"
+        const pathArray = layer.split("/");
+        let current = newConfig.namespaces;
+        pathArray.forEach((part, index) => {
+            if (index === pathArray.length -1 ) {
+                if(!current[part]) {
+                    current[part] = { visible: true };
+                    changed = true;
+                }
+            } else {
+                if (!current[part]) {
+                    current[part] = { visible: true, children: {} };
+                    changed = true; 
+                }
+                 if (!current[part].children) {
+                    current[part].children = {}; // Ensure children object exists
+                    changed = true;
+                }
+                current = current[part].children;
+            }
+        });
+      });
+      return changed ? newConfig : prevConfig;
+    });
+  }, []);
+
+  return {
+    config,
+    setBackgroundColor,
+    setViewBoxWidth,
+    setNamespaceVisibility,
+    initializeNamespaces,
+  };
+};

--- a/src/settings_utils.ts
+++ b/src/settings_utils.ts
@@ -1,0 +1,90 @@
+// This file will contain settings-related utility functions and type definitions.
+
+import { SettingsTreeField, SettingsTreeAction } from "@foxglove/studio";
+
+export interface NamespaceConfig {
+  visible: boolean;
+  children?: { [key: string]: NamespaceConfig };
+}
+
+export interface PanelConfig {
+  backgroundColor: string;
+  viewBoxWidth: number;
+  namespaces: { [key: string]: NamespaceConfig };
+}
+
+export const createNamespaceFields = (namespaces: { [key: string]: NamespaceConfig }): { [key: string]: SettingsTreeField } => {
+  const fields: { [key: string]: SettingsTreeField } = {};
+  const addFieldsRecursive = (ns: { [key: string]: NamespaceConfig }, path: string[] = []) => {
+    for (const [name, { visible, children }] of Object.entries(ns)) {
+      const currentPath = [...path, name];
+      const key = currentPath.join(".");
+      fields[key] = {
+        label: name,
+        input: "boolean",
+        value: visible,
+          help: "Show/hide namespace", // Translated from Japanese
+      };
+      if (children) {
+        addFieldsRecursive(children, currentPath);
+      }
+    }
+  };
+  addFieldsRecursive(namespaces);
+  return fields;
+};
+
+interface SettingsUpdaters {
+  setTopic: (topic: string) => void;
+  setBackgroundColor: (color: string) => void;
+  setViewBoxWidth: (width: number) => void;
+  setNamespaceVisibility: (layerPath: string | string[], isVisible: boolean) => void;
+}
+
+export const handleSettingsAction = (
+  action: SettingsTreeAction,
+  // config: PanelConfig, // config is not directly used for updates, updaters directly change state
+  updaters: SettingsUpdaters
+): void => {
+  const path = action.payload.path; // This is an array of strings
+
+  if (action.action === "update") {
+    const topLevelKey = path[0];
+    const settingKey = path[1]; // For "general" settings
+
+    switch (topLevelKey) {
+      case "general":
+        if (!settingKey) return; // Should not happen with valid paths
+        switch (settingKey) {
+          case "topic":
+            updaters.setTopic(action.payload.value as string);
+            break;
+          case "backgroundColor":
+            updaters.setBackgroundColor(action.payload.value as string);
+            break;
+          case "viewBoxWidth":
+            updaters.setViewBoxWidth(action.payload.value as number);
+            break;
+          default:
+            console.warn(`Unhandled general setting: ${path.join(".")}`);
+        }
+        break;
+      case "namespaces":
+        // Path for namespaces is like ["namespaces", "parent", "child", "grandchild"]
+        // The setNamespaceVisibility function takes the path parts after "namespaces"
+        const namespacePathArray = path.slice(1);
+        const isVisible = action.payload.value as boolean;
+        if (namespacePathArray.length > 0) {
+          updaters.setNamespaceVisibility(namespacePathArray, isVisible);
+        } else {
+          console.warn(`Invalid namespace path: ${path.join(".")}`);
+        }
+        break;
+      default:
+        console.warn(`Unhandled settings action path: ${path.join(".")}`);
+    }
+  } else if (action.action === "perform-node-action") {
+    // Handle any node actions if necessary in the future
+    console.log(`Node action performed: ${action.payload.id}`);
+  }
+};


### PR DESCRIPTION

This commit applies a series of refactorings to the crane visualizer panel to enhance code clarity, structure, and ease of future maintenance.

Key changes include:

1.  **SVG Interaction Hook:**
    *   Pan and zoom logic extracted from `CraneVisualizer` into a reusable
        `usePanZoom` custom hook (`src/hooks/usePanZoom.ts`).

2.  **Centralized Configuration Management:**
    *   A `usePanelConfig` custom hook (`src/hooks/usePanelConfig.ts`) now
        manages the panel's configuration state (background color, viewBox
        width, namespace visibility).
    *   Improved type definitions for `PanelConfig` and `NamespaceConfig`.

3.  **Settings Panel Utilities:**
    *   Logic for creating settings fields (`createNamespaceFields`) and handling
        settings actions (`handleSettingsAction`) moved to `src/settings_utils.ts`.
    *   Shared types (`PanelConfig`, `NamespaceConfig`) also centralized here.

4.  **Readability Enhancements in `CraneVisualizer`:**
    *   Introduced constants for default values (e.g., `DEFAULT_TOPIC`,
        `DEFAULT_VIEWBOX_ASPECT_RATIO`) in `src/constants.ts`.
    *   Translated Japanese comments to English and added new comments to
        clarify complex logic and hook dependencies.
    *   Minor JSX refactoring (e.g., `InfoDisplay` component).
    *   Standardized variable names (e.g., `recv_num` to `receivedMessageCount`).

5.  **Code Cleanup:**
    *   Removed unused variables and imports.
    *   Replaced magic numbers with named constants (e.g., in `usePanZoom`).
    *   Refined React imports for specificity.
    *   Removed the unused `handleCheckboxChange` function from `CraneVisualizer`
        as namespace visibility is now solely managed by the settings panel.

These changes aim to make the codebase more modular, easier to understand, and more robust for future development.